### PR TITLE
MVP -  Jetpack Navigation 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,4 +58,8 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
     //kotlinx-serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    //jetpack-navigation
+    val nav_version = "2.7.5"
+    implementation("androidx.navigation:navigation-fragment-ktx:$nav_version")
+    implementation("androidx.navigation:navigation-ui-ktx:$nav_version")
 }

--- a/app/src/main/java/com/kova700/zerotomvvm/data/source/pokemon/PokemonListItem.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/data/source/pokemon/PokemonListItem.kt
@@ -8,10 +8,10 @@ data class Pokemon(
     @SerialName("name") val name: String,
     @SerialName("url") val detailInfoUrl: String
 ) : Serializable {
-    fun pokemonNum() = detailInfoUrl.split("/".toRegex()).dropLast(1).last().toInt()
+    fun getPokemonNum() = detailInfoUrl.split("/".toRegex()).dropLast(1).last().toInt()
     fun getImageUrl(): String {
         return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/" +
-                "pokemon/other/official-artwork/${pokemonNum()}.png"
+                "pokemon/other/official-artwork/${getPokemonNum()}.png"
     }
 }
 

--- a/app/src/main/java/com/kova700/zerotomvvm/data/source/pokemon/PokemonListItem.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/data/source/pokemon/PokemonListItem.kt
@@ -8,10 +8,10 @@ data class Pokemon(
     @SerialName("name") val name: String,
     @SerialName("url") val detailInfoUrl: String
 ) : Serializable {
+    fun pokemonNum() = detailInfoUrl.split("/".toRegex()).dropLast(1).last().toInt()
     fun getImageUrl(): String {
-        val index = detailInfoUrl.split("/".toRegex()).dropLast(1).last()
         return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/" +
-                "pokemon/other/official-artwork/$index.png"
+                "pokemon/other/official-artwork/${pokemonNum()}.png"
     }
 }
 

--- a/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailContract.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailContract.kt
@@ -5,6 +5,6 @@ import com.kova700.zerotomvvm.data.source.pokemon.PokemonListItem
 interface DetailContract {
     interface View {}
     interface Presenter {
-        fun updateItemData(pokemon: PokemonListItem)
+        fun updateItemData(newItem: PokemonListItem)
     }
 }

--- a/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
@@ -8,12 +8,12 @@ class DetailPresenter(
     val repository: PokemonRepository
 ) : DetailContract.Presenter {
 
-    override fun updateItemData(pokemon: PokemonListItem) {
+    override fun updateItemData(newItem: PokemonListItem) {
         val newList = repository.pokemonList.toMutableList()
-        newList.forEachIndexed { index, pokemonListItem ->
-            if (pokemonListItem.pokemon.name != pokemon.pokemon.name) return@forEachIndexed
-            newList[index] = pokemon
-        }
+        val index = newList.indexOfFirst { it.pokemon.name == newItem.pokemon.name }
+        if (index == -1) return
+
+        newList[index] = newItem
         repository.pokemonList = newList
     }
 

--- a/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
@@ -10,7 +10,7 @@ class DetailPresenter(
 
     override fun updateItemData(newItem: PokemonListItem) {
         val newList = repository.pokemonList.toMutableList()
-        val index = newItem.pokemon.pokemonNum() -1
+        val index = newItem.pokemon.getPokemonNum() -1
         newList[index] = newItem
         repository.pokemonList = newList
     }

--- a/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/view/detail/presenter/DetailPresenter.kt
@@ -10,9 +10,7 @@ class DetailPresenter(
 
     override fun updateItemData(newItem: PokemonListItem) {
         val newList = repository.pokemonList.toMutableList()
-        val index = newList.indexOfFirst { it.pokemon.name == newItem.pokemon.name }
-        if (index == -1) return
-
+        val index = newItem.pokemon.pokemonNum() -1
         newList[index] = newItem
         repository.pokemonList = newList
     }

--- a/app/src/main/java/com/kova700/zerotomvvm/view/main/MainActivity.kt
+++ b/app/src/main/java/com/kova700/zerotomvvm/view/main/MainActivity.kt
@@ -2,46 +2,34 @@ package com.kova700.zerotomvvm.view.main
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
 import com.kova700.zerotomvvm.R
 import com.kova700.zerotomvvm.databinding.ActivityMainBinding
-import com.kova700.zerotomvvm.view.main.home.HomeFragment
-import com.kova700.zerotomvvm.view.main.wish.WishFragment
 
-class MainActivity : AppCompatActivity(R.layout.activity_main) {
+class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
-
-    private val homeFragment by lazy { HomeFragment() }
-    private val wishFragment by lazy { WishFragment() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        initFragmentContainer(savedInstanceState, homeFragment)
-        initBottomNavigationView()
+        initNavigation()
     }
 
-    private fun initBottomNavigationView() {
-        binding.bottomNavigationView.setOnItemSelectedListener { menuItem ->
-            when (menuItem.itemId) {
-                R.id.bottom_menu_home -> showFragment(homeFragment)
-                R.id.bottom_menu_wish -> showFragment(wishFragment)
-            }
-            true
+    private fun initNavigation() {
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.container_main) as NavHostFragment
+        val navController = navHostFragment.findNavController()
+        initBottomNavigationView(navController)
+    }
+
+    private fun initBottomNavigationView(navController: NavController) {
+        binding.bnvMain.apply {
+            setupWithNavController(navController)
         }
-    }
-
-    private fun initFragmentContainer(savedInstanceState: Bundle?, firstFragment: Fragment) {
-        if (savedInstanceState != null) return
-        showFragment(firstFragment)
-    }
-
-    private fun showFragment(targetFragment: Fragment) {
-        supportFragmentManager.beginTransaction()
-            .setReorderingAllowed(true)
-            .replace(R.id.container_main, targetFragment)
-            .commitNow()
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,15 +8,18 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/bottomNavigationView"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph"
+        app:layout_constraintBottom_toTopOf="@+id/bnv_main"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottomNavigationView"
+        android:id="@+id/bnv_main"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/menu/bottom_menu.xml
+++ b/app/src/main/res/menu/bottom_menu.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/bottom_menu_home"
+        android:id="@+id/homeFragment"
         android:icon="@drawable/ic_home_navi"
         android:enabled="true"
         android:title="Home" />
     <item
-        android:id="@+id/bottom_menu_wish"
+        android:id="@+id/wishFragment"
         android:icon="@drawable/ic_heart_navi"
         android:enabled="true"
         android:title="Wish" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/homeFragment">
+
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.kova700.zerotomvvm.view.main.home.HomeFragment"
+        android:label="fragment_home"
+        tools:layout="@layout/fragment_home">
+    </fragment>
+    <fragment
+        android:id="@+id/wishFragment"
+        android:name="com.kova700.zerotomvvm.view.main.wish.WishFragment"
+        android:label="fragment_wish"
+        tools:layout="@layout/fragment_wish">
+    </fragment>
+</navigation>


### PR DESCRIPTION
수정 사항
- DetailPresenter의 updateItemData함수 로직 수정
  - 기존 : pokemon의 name이 같은 Item의 index를 찾아서 heart값 수정한 아이템을 집어넣는 방식
  - 수정 : pokemon의 번호를 이용해서 index를  사용함으로 name이 같은 item index를 찾는 로직 삭제 
- jetpack navigation 적용

추후 PR 반영 예정 사항
- Room적용 + 실시간 데이터 수정 반영
- remote API에서 페이징 적용
- MVVM으로 수정